### PR TITLE
Store the body before finish-callback will be called.

### DIFF
--- a/parse.lisp
+++ b/parse.lisp
@@ -260,11 +260,11 @@
                   (funcall body-callback chunk-data completep))
                 (when multipart-parser
                   (funcall multipart-parser chunk-data))
-                (when (and completep finish-callback)
-                  (funcall finish-callback))
                 (when (http-store-body http)
                   (setf body-bytes (append-array body-bytes chunk-data)
-                        (http-body http) body-bytes)))
+                        (http-body http) body-bytes))
+                (when (and completep finish-callback)
+                  (funcall finish-callback)))
               (return-from parse-wrap (values http t completep))))
           (content-length
             (let* ((body (subseq http-bytes 0 (length http-bytes)))


### PR DESCRIPTION
`http-body` is not set when `finish-callback` is called even though `store-body` is `T`.
This happens only when the request is chunked.

When I was using Wookie without core plugins, it set `http-body` **after** `dispatch-route`.
It looks useless to me, so I assume that is not the right behaviour.
