### PR TITLE
Avoid converting an IP address in headers to a symbol.

### DIFF
--- a/parse.lisp
+++ b/parse.lisp
@@ -73,7 +73,10 @@
         append (let* ((kv (cl-ppcre:split *scanner-header-parse-kv* line :limit 2))
                       (numberp (cl-ppcre:scan *scanner-numeric* (cadr kv)))
                       (val (if numberp
-                               (read-from-string (cadr kv))
+                               (let ((read-val (read-from-string (cadr kv))))
+                                 (if (numberp read-val)
+                                     read-val
+                                     (cadr kv)))
                                (cadr kv))))
                  (list (intern (string-upcase (string-trim #(#\space #\return #\newline) (car kv))) :keyword)
                        val))))


### PR DESCRIPTION
I saw if there's a value which matches `*scanner-numeric*`, http-parse converts it into a number by `read-from-string`.
However, the problem is that `*scanner-numeric*` also matches to an IP address without a port number, which means it will be converted into a "_SYMBOL_", not a string.

Here's an example of "Host" header.

``` common-lisp
(http-parse::convert-headers-plist (format nil "User-Agent: httperf/0.9.0~C~CHost: 127.0.0.1:8080" #\Return #\Newline))
;=> (:USER-AGENT "httperf/0.9.0" :HOST "127.0.0.1:8080")

(type-of (getf * :host))
;=> (SIMPLE-ARRAY CHARACTER (14))
```

``` common-lisp
(http-parse::convert-headers-plist (format nil "User-Agent: httperf/0.9.0~C~CHost: 127.0.0.1" #\Return #\Newline))
;=> (:USER-AGENT "httperf/0.9.0" :HOST |127.0.0.1|)

(type-of (getf * :host))
;=> SYMBOL
```

Guessing this is not intended, I'm sending this small patch.
Needless to say, but don't hesitate to reject this if you have a better solution.
