### PR TITLE
Remove CL-PPCRE completely.

### DIFF
--- a/multipart-parse.lisp
+++ b/multipart-parse.lisp
@@ -1,20 +1,16 @@
 (in-package :http-parse)
 
-(defparameter *scanner-content-disposition-kv-pairs*
-  (cl-ppcre:create-scanner "([a-z-]+)=\"([^\"]+)\"" :case-insensitive-mode t)
-  "Grabs the key/value pairs from a Content-Disposition header.")
-
 (defun get-header-kv-pairs (content-disposition-header-str)
   "Given a content-disposition header value, pull out the key/value pairs in it."
-  (let ((pairs nil))
-    (cl-ppcre:do-matches-as-strings (match *scanner-content-disposition-kv-pairs*
-                                      content-disposition-header-str)
-      (let* ((key (subseq match 0 (position #\= match)))
-             (first-quote (1+ (position #\" match)))
-             (value (subseq match first-quote (position #\" match :start first-quote))))
-        (push value pairs)
-        (push (intern (string-upcase key) :keyword) pairs)))
-    pairs))
+  (loop for kv in (cl-irregsexp:match-split (progn (* (space)) ";" (* (space))) content-disposition-header-str)
+        append
+        (cl-irregsexp:if-match-bind ((key (+ (or (- #\a #\z)
+                                                 (- #\A #\Z)
+                                                 (= #\-))))
+                                     "=\"" value "\"")
+            kv
+            (list (intern (string-upcase key) :keyword)
+                  value))))
 
 (defun make-multipart-parser (headers callback)
   "Make a multipart parser. Returns a closure that accepts a byte array of data

--- a/test/benchmark.lisp
+++ b/test/benchmark.lisp
@@ -1,8 +1,6 @@
 (in-package :http-parse-test)
 
 ;; ---- profile-list ----
-;; cl-ppcre::split
-;; cl-ppcre::scan
 ;; http-parse::get-header-block
 ;; http-parse::convert-headers-plist
 ;; http-parse::parse-headers

--- a/test/multipart.lisp
+++ b/test/multipart.lisp
@@ -23,6 +23,6 @@
       (is (equalp (nth 1 checks)
                   '("power" (:content-disposition "form-data; name=\"power\"") (:name "power") #(103 114 111 119 108) t)))
       (is (equalp (nth 2 checks)
-                  '("uploadz" (:content-disposition "form-data; name=\"uploadz\"; filename=\"test.lisp\"" :content-type "application/octet-stream") (:filename "test.lisp" :name "uploadz") #(40 102 111 114 109 97 116 32 116 32 34) nil)))
+                  '("uploadz" (:content-disposition "form-data; name=\"uploadz\"; filename=\"test.lisp\"" :content-type "application/octet-stream") (:name "uploadz" :filename "test.lisp") #(40 102 111 114 109 97 116 32 116 32 34) nil)))
       (is (equalp (nth 3 checks)
-                  '("uploadz" (:content-disposition "form-data; name=\"uploadz\"; filename=\"test.lisp\"" :content-type "application/octet-stream") (:filename "test.lisp" :name "uploadz") #(111 109 103 108 111 108 119 116 102 126 37 34 41 10) t))))))
+                  '("uploadz" (:content-disposition "form-data; name=\"uploadz\"; filename=\"test.lisp\"" :content-type "application/octet-stream") (:name "uploadz" :filename "test.lisp") #(111 109 103 108 111 108 119 116 102 126 37 34 41 10) t))))))


### PR DESCRIPTION
I'm sorry, this is a bug I introduced in #12.
I forgot to remove CL-PPCRE from multipart-parsing, even though I removed it from `:depends-on` list.
