### PR TITLE
Replace Eos with Fiveam

### DIFF
--- a/http-parse-test.asd
+++ b/http-parse-test.asd
@@ -3,7 +3,7 @@
   :license "MIT"
   :version "0.1"
   :description "Tests for http-parse."
-  :depends-on (#:http-parse #:babel #:eos)
+  :depends-on (#:http-parse #:babel #:fiveam)
   :components
   ((:module test
     :serial t

--- a/test/util.lisp
+++ b/test/util.lisp
@@ -1,5 +1,5 @@
 (defpackage :http-parse-test
-  (:use :cl :eos :http-parse)
+  (:use :cl :fiveam :http-parse)
   (:export #:run-tests))
 (in-package :http-parse-test)
 


### PR DESCRIPTION
Eos has been deprecated in favor of Fiveam